### PR TITLE
Create package for terminology browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,12 @@ build/robot-tree.jar: | build
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
 	RDFTAB_URL := https://github.com/ontodev/rdftab.rs/releases/download/v0.1.1/rdftab-x86_64-apple-darwin
+	JSON_SED := sed 's/\(.*\)	\(.*\)/    "\1": "\2",/'
+	SQL_SED := sed 's/\(.*\)	\(.*\)/("\1", "\2"),/'
 else
 	RDFTAB_URL := https://github.com/ontodev/rdftab.rs/releases/download/v0.1.1/rdftab-x86_64-unknown-linux-musl
+	JSON_SED := sed 's/\(.*\)\t\(.*\)/    "\1": "\2",/'
+	SQL_SED := sed 's/\(.*\)\t\(.*\)/("\1", "\2"),/'
 endif
 
 build/rdftab: | build
@@ -49,8 +53,7 @@ src/ontology/%.tsv: build/terminology.xlsx
 
 build/prefixes.json: src/ontology/prefixes.tsv
 	echo '{ "@context": {' > $@
-	tail -n+2 $< \
-	| sed 's/\(.*\)\t\(.*\)/    "\1": "\2",/' \
+	tail -n+2 $< | $(JSON_SED) \
 	>> $@
 	echo '    "CMI-PB": "http://example.com/cmi-pb/"' >> $@
 	echo '} }' >> $@
@@ -76,8 +79,7 @@ build/prefixes.sql: src/ontology/prefixes.tsv | build
 	echo "  base TEXT NOT NULL" >> $@
 	echo ");" >> $@
 	echo "INSERT OR IGNORE INTO prefix VALUES" >> $@
-	tail -n+2 $< \
-	| sed 's/\(.*\)\t\(.*\)/("\1", "\2"),/' \
+	tail -n+2 $< | $(SQL_SED) \
 	>> $@
 	echo '("CMI-PB", "http://example.com/cmi-pb/");' >> $@
 
@@ -89,7 +91,7 @@ build/cmi-pb.db: build/prefixes.sql cmi-pb.owl | build/rdftab
 
 # Imports
 
-IMPORTS := bfo chebi cl cob go obi pr vo
+IMPORTS := bfo cl cob go obi pr vo
 OWL_IMPORTS := $(foreach I,$(IMPORTS),build/$(I).owl.gz)
 DBS := build/cmi-pb.db $(foreach I,$(IMPORTS),build/$(I).db)
 MODULES := $(foreach I,$(IMPORTS),build/$(I)-import.ttl)

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ build/cmi-pb.db: build/prefixes.sql cmi-pb.owl | build/rdftab
 
 # Imports
 
-IMPORTS := bfo cl cob go obi pr vo
+IMPORTS := bfo chebi cl cob go obi pr vo
 OWL_IMPORTS := $(foreach I,$(IMPORTS),build/$(I).owl.gz)
 DBS := build/cmi-pb.db $(foreach I,$(IMPORTS),build/$(I).db)
 MODULES := $(foreach I,$(IMPORTS),build/$(I)-import.ttl)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ You can install the Python library via `pip`:
 pip install git+https://github.com/jamesaoverton/cmi-pb-terminology.git
 ```
 
-Two environment variables are expected:
-
-1. `CMI_PB_TERMINOLOGY_URL` is the URL of the `cmi-pb.db` file
-2. `CMI_PB_TERMINOLOGY_SECRET`
-
 ## 3. Test Server
 
 We provide a simple Flask server that will serve terminology pages without

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,10 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
+install_requires = ["ontodev-gizmos"]
+
 setup(
-    name="terminology",
+    name="cmi-pb-terminology",
     version="0.0.1",
     description="Terminology tools for the Computational Modelling of Immunology Pertussis Boost project.",
     long_description=long_description,
@@ -22,8 +24,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
+    install_requires=install_requires,
+    packages=find_packages(exclude="test"),
     python_requires=">=3.6, <4",
-    install_requires=["ontodev-gizmos"],
 )

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -4,30 +4,21 @@ import gizmos.tree
 import gizmos.search
 
 from flask import Flask, request, render_template, Response
+from terminology import search, term
 
 app = Flask(__name__)
-predicate_ids = [
-  "rdfs:label",
-  "IAO:0000118",
-  "IAO:0000115",
-  "IAO:0000119",
-  "IAO:0000112",
-  "rdf:type",
-  "rdfs:subClassOf",
-]
+
 
 @app.route("/hook", methods=["POST"])
 def update():
     print("REQUEST", request.json)
     return Response(status=200)
 
-@app.route("/")
-@app.route("/<id>")
-def cmi(id=None):
-    db = "build/cmi-pb.db"
-    if request.args and "text" in request.args:
-        return gizmos.search.search(db, request.args["text"])
-    else:
-        html = gizmos.tree.tree(db, id, title="CMI-PB Terminology", href="./{curie}", predicate_ids=predicate_ids, include_search=False, standalone=True)
-        return html #render_template("base.html", content=html)
 
+@app.route("/")
+@app.route("/<term_id>")
+def cmi(term_id=None):
+    if request.args and "text" in request.args:
+        return search(request.args["text"])
+    else:
+        return term(term_id)

--- a/terminology/__init__.py
+++ b/terminology/__init__.py
@@ -1,0 +1,2 @@
+from terminology.terminology import term
+from terminology.terminology import search

--- a/terminology/terminology.py
+++ b/terminology/terminology.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import gizmos.tree
+import gizmos.search
+
+CMI_PB_DB = "build/cmi-pb.db"
+
+PREDICATE_IDS = [
+    "rdfs:label",
+    "IAO:0000118",
+    "IAO:0000115",
+    "IAO:0000119",
+    "IAO:0000112",
+    "rdf:type",
+    "rdfs:subClassOf",
+]
+
+
+def search(text, db=None):
+    """Search for a term in CMI-PB based on the text label.
+    Return the results in JSON format for Typeahead search."""
+    if not db:
+        db = CMI_PB_DB
+    return gizmos.search.search(db, text)
+
+
+def term(term_id, db=None):
+    """Return the HTML tree browser at a given term ID.
+    If term_id is None, return the top-level."""
+    if not db:
+        db = CMI_PB_DB
+    return gizmos.tree.tree(
+        db,
+        term_id,
+        title="CMI-PB Terminology",
+        href="./{curie}",
+        predicate_ids=PREDICATE_IDS,
+        include_search=False,
+        standalone=True,
+    )


### PR DESCRIPTION
The package, called `terminology`, has two functions:
* `search`: accepts text and returns the JSON search results (based on labels)
* `term`: accepts a term ID and returns the HTML tree browser for `build/cmi-pb.db` at that term

Both have optional `db` parameters if you want to override the default (`build/cmi-pb.db`). Note that if not provided, this is hardcoded, not an env variable. Do we want this to be an env variable @jamesaoverton ?

You can install this using (once this is on master, just remove `@lib`):
```
pip install git+https://github.com/jamesaoverton/cmi-pb-terminology.git@lib
```

Example usage is in [`server.py`](https://github.com/jamesaoverton/cmi-pb-terminology/blob/884aaa5dce5e7cc39d03fd6f21ce88b22d3a7cc2/src/server/server.py)

I also updated the `Makefile` because `sed` on Mac doesn't recognize `\t` as a tab, so you need to use a literal tab...