### PR TITLE
Add OLink proteins to CMI-PB

### DIFF
--- a/cmi-pb.owl
+++ b/cmi-pb.owl
@@ -7,7 +7,8 @@
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:terms="http://purl.org/dc/terms/">
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:cmi-pb="http://example.com/cmi-pb/">
     <owl:Ontology rdf:about="https://cmi-pb.org/terminology/cmi-pb.owl">
         <terms:title rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CMI-PB</terms:title>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Comment</rdfs:comment>
@@ -23,6 +24,14 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
+    
+
+
+    <!-- http://example.com/cmi-pb/shortLabel -->
+
+    <owl:AnnotationProperty rdf:about="http://example.com/cmi-pb/shortLabel">
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">short label</rdfs:label>
+    </owl:AnnotationProperty>
     
 
 
@@ -342,7 +351,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0001057">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A myeloid dendritic cell with the phenotype HLA-DRA-positive.</obo:IAO_0000115>
+        <obo:IAO_0000115>A myeloid dendritic cell with the phenotype HLA-DRA-positive.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">myeloid dendritic cell, human</rdfs:label>
     </owl:Class>
     
@@ -352,7 +361,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0001058">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A plasmacytoid dendritic cell with the phenotype HLA-DRA-positive, CD123-positive, and CD11c-negative.</obo:IAO_0000115>
+        <obo:IAO_0000115>A plasmacytoid dendritic cell with the phenotype HLA-DRA-positive, CD123-positive, and CD11c-negative.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plasmacytoid dendritic cell, human</rdfs:label>
     </owl:Class>
     
@@ -362,7 +371,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0001201">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000000"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A B cell that is CD19-positive.</obo:IAO_0000115>
+        <obo:IAO_0000115>A B cell that is CD19-positive.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B cell, CD19-positive</rdfs:label>
     </owl:Class>
     
@@ -562,6 +571,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000001">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+        <obo:IAO_0000115>A dependent entity that inheres in a bearer by virtue of how the bearer is related to other entities</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">characteristic</rdfs:label>
     </owl:Class>
     
@@ -592,7 +602,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PR_000000001">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/COB_0000013"/>
         <obo:IAO_0000112 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">antithrombin III is a protein</obo:IAO_0000112>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An amino acid chain that is produced de novo by ribosome-mediated translation of a genetically-encoded mRNA, and any derivatives thereof.</obo:IAO_0000115>
+        <obo:IAO_0000115>An amino acid chain that is produced de novo by ribosome-mediated translation of a genetically-encoded mRNA, and any derivatives thereof.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protein</rdfs:label>
     </owl:Class>
     
@@ -758,11 +768,96 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/A6NI73 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/A6NI73">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LILRA5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD85 antigen-like family member F</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immunoglobulin-like transcript 11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leukocyte immunoglobulin-like receptor 9</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leukocyte immunoglobulin-like receptor subfamily A member 5</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/C8C508 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/C8C508">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenylate cyclase toxin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O00161 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O00161">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SNAP23</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vesicle-membrane fusion protein SNAP-23</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Synaptosomal-associated protein 23</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O00182 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O00182">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LGALS9</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ecalectin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor antigen HOM-HD-21</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galectin-9</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O00273 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O00273">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DFFA</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA fragmentation factor 45 kDa subunit</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inhibitor of CAD</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA fragmentation factor subunit alpha</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O14625 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O14625">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL11</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-R1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">H174</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon gamma-inducible protein 9</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon-inducible T-cell alpha chemoattractant</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine B11</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 11</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O14867 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O14867">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BACH1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTB and CNC homolog 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HA2303</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transcription regulator protein BACH1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O15123 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O15123">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANGPT2</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-2</rdfs:label>
     </owl:Class>
     
 
@@ -776,11 +871,443 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/O43240 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43240">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KLK10</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Normal epithelial cell-specific 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protease serine-like 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kallikrein-10</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43508 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43508">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFSF12</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APO3 ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF-related weak inducer of apoptosis</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 12</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43557 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43557">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFSF14</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Herpes virus entry mediator ligand</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 14</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43597 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43597">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SPRY2</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein sprouty homolog 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43736 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43736">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITM2A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein E25</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integral membrane protein 2A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43827 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43827">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANGPTL7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-like factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-like protein 7</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cornea-derived transcript 6 protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-related protein 7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O43927 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O43927">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL13</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angie</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B cell-attracting chemokine 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B lymphocyte chemoattractant</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXC chemokine BLC</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine B13</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 13</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O60449 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O60449">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LY75</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 13 member B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DEC-205</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gp200-MR6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte antigen 75</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O60880 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O60880">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH2D1A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Duncan disease SH2-protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Signaling lymphocytic activation molecule-associated protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell signal transduction molecule SAP</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH2 domain-containing protein 1A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O75144 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O75144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICOSLG</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B7 homolog 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B7-like protein Gl50</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B7-related protein 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICOS ligand</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O75356 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O75356">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENTPD5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD39 antigen-like 4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ER-UDPase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Guanosine-diphosphatase ENTPD5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nucleoside diphosphatase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uridine-diphosphatase ENTPD5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ectonucleoside triphosphate diphosphohydrolase 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O75475 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O75475">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PSIP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLL-associated antigen KW-7</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dense fine speckles 70 kDa protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lens epithelium-derived growth factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transcriptional coactivator p75/p52</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PC4 and SFRS1-interacting protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O75509 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O75509">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFRSF21</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Death receptor 6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 21</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O75791 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O75791">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRAP2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adapter protein GRID</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRB-2-like protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRBLG</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRBX</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Grf40 adapter protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Growth factor receptor-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hematopoietic cell-associated adapter protein GrpL</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P38</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein GADS</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH3-SH2-SH3 adapter Mona</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRB2-related adapter protein 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O76036 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O76036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCR1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte antigen 94 homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell-activating receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cell p46-related protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural cytotoxicity triggering receptor 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O94992 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O94992">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HEXIM1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cardiac lineage protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Estrogen down-regulated gene 1 protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hexamethylene bis-acetamide-inducible protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Menage a quatre protein 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein HEXIM1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95502 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95502">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPTXR</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuronal pentraxin receptor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95544 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95544">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NADK</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poly(P)/ATP NAD kinase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NAD kinase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95727 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRTAM</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Class-I MHC-restricted T-cell-associated molecule</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic and regulatory T-cell molecule</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95760 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95760">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL33</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-1 family member 11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nuclear factor from high endothelial venules</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-33</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95786 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95786">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DDX58</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DEAD box protein 58</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Probable ATP-dependent RNA helicase DDX58</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RIG-I-like receptor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoic acid-inducible gene 1 protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinoic acid-inducible gene I protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antiviral innate immune response receptor RIG-I</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/O95841 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/O95841">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANGPTL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-like protein 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-related protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P00352 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P00352">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ALDH1A1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ALDH-E1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ALHDII</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aldehyde dehydrogenase family 1 member A1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aldehyde dehydrogenase, cytosolic</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinal dehydrogenase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P00813 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P00813">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADA</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosine aminohydrolase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosine deaminase</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/P01012 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ovalbumin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01127 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01127">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDGFB</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDGF-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Platelet-derived growth factor B chain</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Platelet-derived growth factor beta polypeptide</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proto-oncogene c-Sis</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Platelet-derived growth factor subunit B</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01133 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01133">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EGF</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pro-epidermal growth factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01137 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01137">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGFB1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transforming growth factor beta-1 proprotein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01222 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01222">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TSHB</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thyroid-stimulating hormone subunit beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thyrotropin beta chain</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thyrotropin subunit beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01375 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01375">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cachectin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF-alpha</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01574 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01574">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFNB1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fibroblast interferon</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01579 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01579">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFNG</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immune interferon</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon gamma</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01583 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01583">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL1A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hematopoietin-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-1 alpha</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01730 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01730">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell surface antigen T4/Leu-3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell surface glycoprotein CD4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P01732 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P01732">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD8A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-lymphocyte differentiation antigen T8/Leu-2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell surface glycoprotein CD8 alpha chain</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P02778 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P02778">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL10</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">10 kDa interferon gamma-induced protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine B10</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 10</rdfs:label>
     </owl:Class>
     
 
@@ -830,11 +1357,330 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/P05089 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P05089">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARG1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liver-type arginase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Type I arginase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Arginase-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P05112 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P05112">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell stimulatory factor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Binetrakin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte stimulatory factor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pitrakinra</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P05113 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P05113">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell differentiation factor I</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eosinophil differentiation factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell replacing factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P05231 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P05231">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell stimulatory factor 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CTL differentiation factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hybridoma growth factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon beta-2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P05412 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P05412">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">JUN</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Activator protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proto-oncogene c-Jun</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">V-jun avian sarcoma virus 17 oncogene homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p39</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transcription factor AP-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P06127 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P06127">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte antigen T1/Leu-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell surface glycoprotein CD5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P07585 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P07585">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DCN</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bone proteoglycan II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PG-S2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PG40</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Decorin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P08727 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P08727">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KRT19</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytokeratin-19</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keratin-19</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Keratin, type I cytoskeletal 19</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09038 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09038">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FGF2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Basic fibroblast growth factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding growth factor 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fibroblast growth factor 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09104 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09104">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENO2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2-phospho-D-glycerate hydro-lyase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Enolase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neural enolase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neuron-specific enolase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gamma-enolase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09237 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MMP7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matrin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matrix metalloproteinase-7</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pump-1 protease</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Uterine metalloproteinase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matrilysin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09341 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09341">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GRO-alpha(1-73)</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Melanoma growth stimulatory activity</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neutrophil-activating protein 3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Growth-regulated alpha protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09382 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09382">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LGALS1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">14 kDa laminin-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">14 kDa lectin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-galactoside-binding lectin L-14-I</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galaptin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HBL</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HPL</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lactose-binding lectin 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lectin galactoside-binding soluble 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Putative MAPK-activating protein PM12</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S-Lac lectin 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galectin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09417 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09417">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">QDPR</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HDHPR</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Quinoid dihydropteridine reductase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short chain dehydrogenase/reductase family 33C member 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dihydropteridine reductase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09467 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09467">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-fructose-1,6-bisphosphate 1-phosphohydrolase 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liver FBPase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fructose-1,6-bisphosphatase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09525 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09525">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANXA4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">35-beta calcimedin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin IV</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin-4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbohydrate-binding protein p33/p41</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chromobindin-4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endonexin I</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lipocortin IV</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P32.5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PP4-X</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placental anticoagulant protein II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein II</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin A4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09601 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09601">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HMOX1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heme oxygenase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09603 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09603">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CSF1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lanimostim</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage colony-stimulating factor 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P09668 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P09668">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CTSH</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pro-cathepsin H</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/P0A3R5 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P0A3R5">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P10144 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P10144">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GZMB</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CTLA-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cathepsin G-like 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic T-lymphocyte proteinase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fragmentin-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granzyme-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human lymphocyte protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SECT</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell serine protease 1-3E</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granzyme B</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P10145 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P10145">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL8</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chemokine (C-X-C motif) ligand 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Emoctakin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granulocyte chemotactic protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte-derived neutrophil chemotactic factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte-derived neutrophil-activating peptide</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neutrophil-activating protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein 3-10C</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell chemotactic factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-8</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P10147 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P10147">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G0/G1 switch regulatory protein 19-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage inflammatory protein 1-alpha</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAT 464.1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIS-beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tonsillar lymphocyte LD78 alpha protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P10747 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P10747">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD28</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TP44</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell-specific surface glycoprotein CD28</rdfs:label>
     </owl:Class>
     
 
@@ -848,11 +1694,122 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/P12544 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P12544">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GZMA</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CTL tryptase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic T-lymphocyte proteinase 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fragmentin-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granzyme-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hanukkah factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granzyme A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P12724 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P12724">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RNASE3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ribonuclease 3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eosinophil cationic protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P13232 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P13232">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL7</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P13236 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P13236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G-26 T-lymphocyte-secreted protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HC21</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte activation gene 1 protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIP-1-beta(1-69)</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage inflammatory protein 1-beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAT 744</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein H400</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIS-gamma</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell activation protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P13500 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P13500">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HC11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemoattractant protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemotactic and activating factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemotactic protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte secretory protein JE</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P13611 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P13611">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VCAN</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chondroitin sulfate proteoglycan core protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glial hyaluronate-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Large fibroblast proteoglycan</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PG-M</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Versican core protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P14210 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P14210">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HGF</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatopoietin-A</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scatter factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatocyte growth factor</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/P14283 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P14283">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertactin autotransporter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P14317 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P14317">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HCLS1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hematopoietic cell-specific LYN substrate 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LckBP1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p75</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hematopoietic lineage cell-specific protein</rdfs:label>
     </owl:Class>
     
 
@@ -866,6 +1823,411 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/P15514 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P15514">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AREG</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Colorectum cell-derived growth factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amphiregulin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P15692 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P15692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VEGFA</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vascular permeability factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vascular endothelial growth factor A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P16083 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P16083">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NQO2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NRH dehydrogenase [quinone] 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NRH:quinone oxidoreductase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Quinone reductase 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ribosyldihydronicotinamide dehydrogenase [quinone]</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P16278 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P16278">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GLB1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acid beta-galactosidase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Elastin receptor 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-galactosidase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P16455 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P16455">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MGMT</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">6-O-methylguanine-DNA methyltransferase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">O-6-methylguanine-DNA-alkyltransferase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Methylated-DNA--protein-cysteine methyltransferase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P18564 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P18564">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITGB6</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integrin beta-6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P18627 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P18627">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LAG3</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte activation gene 3 protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P19022 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P19022">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDH2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDw325</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neural cadherin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cadherin-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P19474 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P19474">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRIM21</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">52 kDa Ro protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">52 kDa ribonucleoprotein autoantigen Ro/SS-A</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING finger protein 81</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING-type E3 ubiquitin transferase TRIM21</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ro(SS-A)</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sjoegren syndrome type A antigen</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tripartite motif-containing protein 21</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E3 ubiquitin-protein ligase TRIM21</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P19971 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P19971">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TYMP</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gliostatin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Platelet-derived endothelial cell growth factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TdRPase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thymidine phosphorylase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P20711 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P20711">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DDC</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DOPA decarboxylase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aromatic-L-amino-acid decarboxylase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P20718 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P20718">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GZMH</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCP-X</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cathepsin G-like 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic T-lymphocyte proteinase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic serine protease C</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Granzyme H</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P21246 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P21246">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTN</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding brain mitogen</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding growth factor 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding growth-associated molecule</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding neurite outgrowth-promoting factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Heparin-binding neurite outgrowth-promoting factor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Osteoblast-specific factor 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pleiotrophin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P21964 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P21964">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">COMT</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Catechol O-methyltransferase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P22301 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P22301">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL10</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytokine synthesis inhibitory factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-10</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P22466 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P22466">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GAL</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Galanin peptides</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P23229 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P23229">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITGA6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD49 antigen-like family member F</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VLA-6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integrin alpha-6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P23526 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P23526">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AHCY</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S-adenosyl-L-homocysteine hydrolase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adenosylhomocysteinase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P25815 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P25815">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S100P</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Migration-inducing gene 9 protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein S100-E</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S100 calcium-binding protein P</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein S100-P</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P25942 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P25942">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD40</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell surface antigen CD40</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Bp50</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD40L receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDw40</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P26010 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P26010">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITGB7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gut homing receptor beta subunit</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integrin beta-7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P26842 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P26842">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD27</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD27L receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell activation antigen CD27</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T14</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 7</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD27 antigen</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P27540 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P27540">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ARNT</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Class E basic helix-loop-helix protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dioxin receptor, nuclear translocator</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypoxia-inducible factor 1-beta</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Aryl hydrocarbon receptor nuclear translocator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P27695 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P27695">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APEX1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APEX nuclease</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apurinic-apyrimidinic endonuclease 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REF-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Redox factor-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DNA-(apurinic or apyrimidinic site) endonuclease</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P28845 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P28845">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSD11B1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">11-beta-hydroxysteroid dehydrogenase 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Short chain dehydrogenase/reductase family 26C member 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corticosteroid 11-beta-dehydrogenase isozyme 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P29017 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P29017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD1C</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell surface glycoprotein CD1c</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P29459 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P29459">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL12A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic lymphocyte maturation factor 35 kDa subunit</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL-12 subunit p35</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell stimulatory factor chain 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-12 subunit alpha</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P29460 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P29460">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL12B</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytotoxic lymphocyte maturation factor 40 kDa subunit</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL-12 subunit p40</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell stimulatory factor chain 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-12 subunit beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P29474 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P29474">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NOS3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Constitutive NOS</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EC-NOS</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endothelial NOS</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NOS type III</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nitric oxide synthase, endothelial</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P29965 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P29965">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD40LG</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell antigen Gp39</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF-related activation protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD40 ligand</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P30044 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P30044">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRDX5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alu corepressor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antioxidant enzyme B166</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liver tissue 2D-page spot 71B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLP</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxiredoxin V</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxisomal antioxidant enzyme</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TPx type VI</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin peroxidase PMP20</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-dependent peroxiredoxin 5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxiredoxin-5, mitochondrial</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P30048 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P30048">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRDX3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Antioxidant protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HBC189</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxiredoxin III</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxiredoxin-3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein MER5 homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-dependent peroxiredoxin 3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-dependent peroxide reductase, mitochondrial</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/P30438 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P30438">
@@ -875,11 +2237,1067 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     
 
 
+    <!-- https://www.uniprot.org/uniprot/P31431 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P31431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SDC4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amphiglycan</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ryudocan core protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Syndecan-4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P32970 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P32970">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD70</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD27 ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 7</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD70 antigen</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P34130 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P34130">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NTF4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurotrophin-5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neutrophic factor 4</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurotrophin-4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P35225 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P35225">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL13</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-13</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P35237 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P35237">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SERPINB6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytoplasmic antiproteinase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidase inhibitor 6</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placental thrombin inhibitor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serpin B6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P35240 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P35240">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NF2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Moesin-ezrin-radixin-like protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurofibromin-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schwannomerlin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Schwannomin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Merlin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P35754 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P35754">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GLRX</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioltransferase-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutaredoxin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P35968 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P35968">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KDR</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fetal liver kinase 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kinase insert domain receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein-tyrosine kinase receptor flk-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vascular endothelial growth factor receptor 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P39900 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P39900">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MMP12</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage elastase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Matrix metalloproteinase-12</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage metalloelastase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P40259 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P40259">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD79B</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell-specific glycoprotein B29</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ig-beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immunoglobulin-associated B29 protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell antigen receptor complex-associated protein beta chain</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P40818 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P40818">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">USP8</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Deubiquitinating enzyme 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubiquitin isopeptidase Y</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubiquitin thioesterase 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubiquitin-specific-processing protease 8</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ubiquitin carboxyl-terminal hydrolase 8</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P41236 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P41236">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPP1R2</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein phosphatase inhibitor 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P42701 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P42701">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL12RB1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL-12 receptor beta component</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-12 receptor subunit beta-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P42830 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P42830">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENA-78(1-78)</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epithelial-derived neutrophil-activating protein 78</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neutrophil-activating peptide ENA-78</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine B5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P43234 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P43234">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CTSO</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cathepsin O</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P43489 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P43489">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFRSF4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACT35 antigen</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OX40L receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAX transcriptionally-activated glycoprotein 1 receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P46109 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P46109">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CRKL</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Crk-like protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P46379 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P46379">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAG6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAG family molecular chaperone regulator 6</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BCL2-associated athanogene 6</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HLA-B-associated transcript 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein G3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein Scythe</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Large proline-rich protein BAG6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P48023 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P48023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FASLG</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apoptosis antigen ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD95 ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fas antigen ligand</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P48061 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P48061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL12</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 12</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Intercrine reduced in hepatomas</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pre-B cell growth-stimulating factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stromal cell-derived factor 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P48740 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P48740">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MASP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Complement factor MASP-3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Complement-activating component of Ra-reactive factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mannose-binding lectin-associated serine protease 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mannose-binding protein-associated serine protease</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ra-reactive factor serine protease p100</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serine protease 5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mannan-binding lectin serine protease 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P49763 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P49763">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PGF</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Placenta growth factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P49767 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P49767">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VEGFC</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Flt4 ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vascular endothelial growth factor-related protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Vascular endothelial growth factor C</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P50135 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P50135">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HNMT</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Histamine N-methyltransferase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P50452 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P50452">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SERPINB8</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytoplasmic antiproteinase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidase inhibitor 8</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serpin B8</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P50591 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P50591">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFSF10</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apo-2 ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF-related apoptosis-inducing ligand</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor ligand superfamily member 10</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P50995 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P50995">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANXA11</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">56 kDa autoantigen</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin XI</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin-11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calcyclin-associated annexin 50</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annexin A11</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P51617 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P51617">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IRAK1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-1 receptor-associated kinase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P51671 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P51671">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL11</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eosinophil chemotactic protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A11</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eotaxin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P51693 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P51693">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">APLP1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Amyloid-like protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P51858 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P51858">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HDGF</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">High mobility group protein 1-like 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hepatoma-derived growth factor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P52294 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P52294">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KPNA1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Karyopherin subunit alpha-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nucleoprotein interactor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RAG cohort protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SRP1-beta</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Importin subunit alpha-5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P52823 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P52823">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">STC1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Stanniocalcin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P52888 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P52888">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">THOP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endopeptidase 24.15</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MP78</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thimet oligopeptidase</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P55773 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P55773">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL23</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CK-beta-8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage inflammatory protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myeloid progenitor inhibitory factor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A23</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 23</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P58499 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P58499">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAM3B</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytokine-like protein 2-21</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pancreatic-derived factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein FAM3B</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P60568 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P60568">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell growth factor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P63241 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P63241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EIF5A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eukaryotic initiation factor 5A isoform 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rev-binding factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">eIF-4D</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eukaryotic translation initiation factor 5A-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P78310 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P78310">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXADR</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CVB3-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackievirus B-adenovirus receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HCVADR</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackievirus and adenovirus receptor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P78362 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P78362">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SRPK2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SFRS protein kinase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Serine/arginine-rich protein-specific kinase 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SRSF protein kinase 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P78410 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P78410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTN3A2</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Butyrophilin subfamily 3 member A2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P78423 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P78423">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CX3CL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X3-C motif chemokine 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CX3C membrane-anchored chemokine</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurotactin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine D1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fractalkine</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P78556 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P78556">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL20</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-chemokine exodus-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CC chemokine LARC</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liver and activation-regulated chemokine</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage inflammatory protein 3 alpha</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A20</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 20</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P80075 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P80075">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL8</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HC14</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemoattractant protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemotactic protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A8</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 8</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P80098 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P80098">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemoattractant protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemotactic protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NC28</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A7</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/P98082 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/P98082">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAB2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adaptor molecule disabled-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Differentially expressed in ovarian carcinoma 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Differentially-expressed protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Disabled homolog 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q00978 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q00978">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IRF9</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFN-alpha-responsive transcription factor subunit</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISGF3 p48 subunit</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon-stimulated gene factor 3 gamma</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transcriptional regulator ISGF3 subunit gamma</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon regulatory factor 9</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q01151 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q01151">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD83</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell activation protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell surface protein HB15</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD83 antigen</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q01973 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q01973">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ROR1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurotrophic tyrosine kinase, receptor-related 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inactive tyrosine-protein kinase transmembrane receptor ROR1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q02763 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q02763">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TEK</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endothelial tyrosine kinase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tunica interna endothelial cell kinase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine kinase with Ig and EGF homology domains-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase receptor TEK</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase receptor TIE-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p140 TEK</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-1 receptor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q02790 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q02790">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FKBP4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">51 kDa FK506-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">52 kDa FK506-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">59 kDa immunophilin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FK506-binding protein 4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FKBP59</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HSP-binding immunophilin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immunophilin FKBP52</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Rotamase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidyl-prolyl cis-trans isomerase FKBP4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q03403 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q03403">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TFF2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spasmolysin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spasmolytic polypeptide</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Trefoil factor 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q03431 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q03431">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTH1R</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PTH/PTHrP type I receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parathyroid hormone 1 receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Parathyroid hormone/parathyroid hormone-related peptide receptor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q04637 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q04637">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EIF4G1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p220</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Eukaryotic translation initiation factor 4 gamma 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q04759 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q04759">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRKCQ</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nPKC-theta</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein kinase C theta type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q04900 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q04900">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD164</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endolyn</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multi-glycosylated core protein 24</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sialomucin core protein 24</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q05084 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q05084">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICA1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">69 kDa islet cell autoantigen</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Islet cell autoantigen p69</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Islet cell autoantigen 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q05516 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q05516">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZBTB16</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Promyelocytic leukemia zinc finger protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc finger protein 145</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc finger protein PLZF</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Zinc finger and BTB domain-containing protein 16</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q06418 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q06418">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TYRO3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase BYK</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase DTK</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase RSE</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase SKY</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase TIF</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tyrosine-protein kinase receptor TYRO3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q06830 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q06830">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PRDX1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cell-enhancing factor A</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Proliferation-associated gene protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin peroxidase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-dependent peroxide reductase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-dependent peroxiredoxin 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peroxiredoxin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q07011 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q07011">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFRSF9</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">4-1BB ligand receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDw137</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell antigen 4-1BB homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell antigen ILA</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 9</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q07065 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q07065">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CKAP4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">63-kDa cytoskeleton-linking membrane protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytoskeleton-associated protein 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q07325 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q07325">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXCL9</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gamma-interferon-induced monokine</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monokine induced by interferon-gamma</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine B9</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-X-C motif chemokine 9</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q12933 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q12933">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRAF2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">E3 ubiquitin-protein ligase TRAF2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING-type E3 ubiquitin transferase TRAF2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor type 2 receptor-associated protein 3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNF receptor-associated factor 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q12968 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q12968">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NFATC3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NFATx</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">T-cell transcription factor NFAT4</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nuclear factor of activated T-cells, cytoplasmic 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q13241 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q13241">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KLRD1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KP43</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Killer cell lectin-like receptor subfamily D member 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cells antigen CD94</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q13275 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q13275">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SEMA3F</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sema III/F</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Semaphorin IV</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Semaphorin-3F</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q13490 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q13490">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BIRC2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cellular inhibitor of apoptosis 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IAP homolog B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inhibitor of apoptosis protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING finger protein 48</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING-type E3 ubiquitin transferase BIRC2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFR2-TRAF-signaling complex protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Baculoviral IAP repeat-containing protein 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q13574 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q13574">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DGKZ</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diglyceride kinase zeta</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diacylglycerol kinase zeta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q14116 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q14116">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL18</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Iboctadekin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon gamma-inducing factor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-1 gamma</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-18</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q14203 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q14203">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DCTN1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">150 kDa dynein-associated polypeptide</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAP-150</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p135</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p150-glued</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dynactin subunit 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q14213 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q14213">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EBI3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epstein-Barr virus-induced gene 3 protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-27 subunit beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q14435 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q14435">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GALNT3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Polypeptide GalNAc transferase 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein-UDP acetylgalactosaminyltransferase 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UDP-GalNAc:polypeptide N-acetylgalactosaminyltransferase 3</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Polypeptide N-acetylgalactosaminyltransferase 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q14790 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q14790">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CASP8</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apoptotic cysteine protease</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apoptotic protease Mch-5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CAP4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FADD-homologous ICE/ced-3-like protease</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FADD-like ICE</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ICE-like apoptotic protease 5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MORT1-associated ced-3 homolog</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Caspase-8</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- https://www.uniprot.org/uniprot/Q15116 -->
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15116">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDCD1</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Programmed cell death protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q15155 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15155">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NOMO1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pM5 protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nodal modulator 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q15389 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15389">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ANGPT1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Angiopoietin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q15517 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15517">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDSN</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corneodesmosin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q15661 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15661">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TPSAB1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tryptase I</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tryptase alpha-1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tryptase alpha/beta-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q15846 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q15846">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLUL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Retinal-specific clusterin-like protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Clusterin-like protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q16773 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q16773">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">KYAT1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cysteine-S-conjugate beta-lyase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutamine transaminase K</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glutamine--phenylpyruvate transaminase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kynurenine aminotransferase 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kynurenine aminotransferase I</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kynurenine--oxoglutarate transaminase I</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Kynurenine--oxoglutarate transaminase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q16790 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q16790">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CA9</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonate dehydratase IX</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonic anhydrase IX</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Membrane antigen MN</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">P54/58N</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Renal cell carcinoma-associated antigen G250</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">pMW1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonic anhydrase 9</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q16820 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q16820">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MEP1B</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endopeptidase-2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Meprin B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">N-benzoyl-L-tyrosyl-P-amino-benzoic acid hydrolase subunit beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PABA peptide hydrolase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPH beta</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Meprin A subunit beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q29980 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q29980">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MICB</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MHC class I polypeptide-related sequence B</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q29983 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q29983">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MICA</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MHC class I polypeptide-related sequence A</rdfs:label>
     </owl:Class>
     
 
@@ -898,6 +3316,913 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q5PY51">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diphtheria toxin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q641Q3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q641Q3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">METRNL</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Subfatin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Meteorin-like protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6DN72 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6DN72">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FCRL6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor homolog 6</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFGP6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor-like protein 6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6EIG7 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6EIG7">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC6A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 10</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dendritic cell-associated C-type lectin 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 6 member A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6UWV6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6UWV6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENPP7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alkaline sphingomyelin phosphodiesterase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Intestinal alkaline sphingomyelinase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ectonucleotide pyrophosphatase/phosphodiesterase family member 7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6UXB4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6UXB4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC4G</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Liver and lymph node sinusoidal endothelial cell C-type lectin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 4 member G</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6WN34 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6WN34">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CHRDL2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Breast tumor novel factor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chordin-related protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Chordin-like protein 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q6ZUJ8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q6ZUJ8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PIK3AP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell adapter for phosphoinositide 3-kinase</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell phosphoinositide 3-kinase adapter protein 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phosphoinositide 3-kinase adapter protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q76M96 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q76M96">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCDC80</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Down-regulated by oncogenes protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Up-regulated in BRS-3 deficient mouse homolog</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coiled-coil domain-containing protein 80</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q7Z6M3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q7Z6M3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MILR1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allergy inhibitory receptor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mast cell antigen 32</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mast cell immunoglobulin-like receptor 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Allergin-1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q86VZ4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q86VZ4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LRP11</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Low-density lipoprotein receptor-related protein 11</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8IU57 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8IU57">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFNLR1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytokine receptor class-II member 12</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cytokine receptor family 2 member 12</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-28 receptor subunit alpha</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Likely interleukin or cytokine receptor 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interferon lambda receptor 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8IZP9 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8IZP9">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADGRG2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G-protein coupled receptor 64</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Human epididymis-specific protein 6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adhesion G-protein coupled receptor G2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8N1Q1 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8N1Q1">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CA13</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonate dehydratase XIII</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonic anhydrase XIII</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Carbonic anhydrase 13</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8N608 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8N608">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DPP10</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase IV-related protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase X</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase-like protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inactive dipeptidyl peptidase 10</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8NBJ7 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8NBJ7">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SUMF2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paralog of formylglycine-generating enzyme</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sulfatase-modifying factor 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Inactive C-alpha-formylglycine-generating enzyme 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8NBS9 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8NBS9">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TXNDC5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endoplasmic reticulum resident protein 46</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin-like protein p46</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thioredoxin domain-containing protein 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8NHJ6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8NHJ6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LILRB4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD85 antigen-like family member K</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immunoglobulin-like transcript 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leukocyte immunoglobulin-like receptor 5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte inhibitory receptor HM18</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leukocyte immunoglobulin-like receptor subfamily B member 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8NI22 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8NI22">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MCFD2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neural stem cell-derived neuronal survival protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Multiple coagulation factor deficiency protein 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8WTT0 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8WTT0">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC4C</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Blood dendritic cell antigen 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 7</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dendritic lectin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 4 member C</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8WTU2 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8WTU2">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SSC4D</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Four scavenger receptor cysteine-rich domains-containing protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">S4D-SRCRB</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Scavenger receptor cysteine-rich domain-containing group B protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8WVQ1 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8WVQ1">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CANT1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Apyrase homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Putative MAPK-activating protein PM09</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Putative NF-kappa-B-activating protein 107</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Soluble calcium-activated nucleotidase 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8WX77 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8WX77">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IGFBPL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IGFBP-related protein 10</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like growth factor-binding-related protein 4</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Insulin-like growth factor-binding protein-like 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q8WXI8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q8WXI8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC4D</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 8</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin-like receptor 6</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 4 member D</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q92520 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q92520">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FAM3C</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-like EMT inducer</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein FAM3C</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q92583 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q92583">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL17</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CC chemokine TARC</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A17</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Thymus and activation-regulated chemokine</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 17</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q92692 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q92692">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NECTIN2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Herpes virus entry mediator B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nectin cell adhesion molecule 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Poliovirus receptor-related protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nectin-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q92844 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q92844">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TANK</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRAF-interacting protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRAF family member-associated NF-kappa-B activator</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96DB9 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96DB9">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FXYD5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dysadherin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FXYD domain-containing ion transport regulator 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96JA1 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96JA1">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LRIG1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Leucine-rich repeats and immunoglobulin-like domains protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96LA6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96LA6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FCRL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor homolog 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFGP family protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immune receptor translocation-associated protein 5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor-like protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96P31 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96P31">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FCRL3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor homolog 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IFGP family protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Immune receptor translocation-associated protein 3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH2 domain-containing phosphatase anchor protein 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fc receptor-like protein 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96PD2 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96PD2">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DCBLD2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CUB, LCCL and coagulation factor V/VIII-homology domains protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endothelial and smooth muscle cell-derived neuropilin-like protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Discoidin, CUB and LCCL domain-containing protein 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q96SB3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q96SB3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PPP1R9B</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurabin-II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein phosphatase 1 regulatory subunit 9B</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Spinophilin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neurabin-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q99616 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q99616">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL13</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CK-beta-10</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemoattractant protein 4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Monocyte chemotactic protein 4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NCC-1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A13</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 13</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q99731 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q99731">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CCL19</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-chemokine exodus-3</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CK beta-11</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Epstein-Barr virus-induced molecule 1 ligand chemokine</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Macrophage inflammatory protein 3 beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Small-inducible cytokine A19</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-C motif chemokine 19</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BQ51 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BQ51">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PDCD1LG2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Butyrophilin B7-DC</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Programmed cell death 1 ligand 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BQB4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BQB4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SOST</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sclerostin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BXN2 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BXN2">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC7A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Beta-glucan receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 12</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dendritic cell-associated C-type lectin 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 7 member A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BYZ8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BYZ8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REG4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Gastrointestinal secretory protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">REG-like protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Regenerating islet-derived protein IV</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Regenerating islet-derived protein 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BZR6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BZR6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RTN4R</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nogo receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Nogo-66 receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Reticulon-4 receptor</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9BZW8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9BZW8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD244</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell activation-inducing ligand</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NK cell type I receptor protein 2B4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SLAM family member 4</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Signaling lymphocytic activation molecule 4</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Natural killer cell receptor 2B4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9C035 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9C035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TRIM5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING finger protein 88</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RING-type E3 ubiquitin transferase TRIM5</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tripartite motif-containing protein 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9GZM7 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9GZM7">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TINAGL1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Glucocorticoid-inducible protein 5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Oxidized LDL-responsive gene 2 protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tubulointerstitial nephritis antigen-related protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tubulointerstitial nephritis antigen-like</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9GZT9 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9GZT9">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EGLN1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Hypoxia-inducible factor prolyl hydroxylase 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Prolyl hydroxylase domain-containing protein 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SM-20</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Egl nine homolog 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9H4D0 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9H4D0">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLSTN2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Alcadein-gamma</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Calsyntenin-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9H6B4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9H6B4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLMP</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adipocyte adhesion molecule</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Coxsackie- and adenovirus receptor-like membrane protein</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CXADR-like membrane protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9HBB8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9HBB8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDHR5</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mu-protocadherin</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mucin and cadherin-like protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Mucin-like protocadherin</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cadherin-related family member 5</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9HBE4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9HBE4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IL21</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Za11</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-21</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9HCM2 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9HCM2">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PLXNA4</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Plexin-A4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NP84 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NP84">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TNFRSF12A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fibroblast growth factor-inducible immediate-early response protein 14</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tweak-receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member 12A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NP99 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NP99">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TREM1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Triggering receptor expressed on monocytes 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Triggering receptor expressed on myeloid cells 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NPH0 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NPH0">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ACP6</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acid phosphatase 6, lysophosphatidic</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Acid phosphatase-like protein 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PACPL1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lysophosphatidic acid phosphatase type 6</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NQX5 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NQX5">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NPDC1</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Neural proliferation differentiation and control protein 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NR28 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NR28">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DIABLO</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Direct IAP-binding protein with low pI</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Second mitochondria-derived activator of caspase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Diablo homolog, mitochondrial</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NWQ8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NWQ8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAG1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Csk-binding protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transmembrane adapter protein PAG</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Transmembrane phosphoprotein Cbp</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Phosphoprotein associated with glycosphingolipid-enriched microdomains 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NWZ3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NWZ3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IRAK4</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Renal carcinoma antigen NY-REN-64</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interleukin-1 receptor-associated kinase 4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NY25 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NY25">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC5A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 5</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Myeloid DAP12-associating lectin 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 5 member A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9NZQ7 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9NZQ7">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD274</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B7 homolog 1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Programmed cell death 1 ligand 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UBU3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UBU3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GHRL</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Growth hormone secretagogue</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Growth hormone-releasing peptide</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Motilin-related peptide</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein M46</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Appetite-regulating hormone</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UHC6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UHC6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CNTNAP2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell recognition molecule Caspr2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Contactin-associated protein-like 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UHL4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UHL4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DPP7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl aminopeptidase II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase 7</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Quiescent cell proline dipeptidase</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dipeptidyl peptidase 2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UHX3 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UHX3">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADGRE2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EGF-like module receptor 2</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EGF-like module-containing mucin-like hormone receptor-like 2</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adhesion G protein-coupled receptor E2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UKJ0 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UKJ0">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PILRB</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Activating receptor PILR-beta</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cell surface receptor FDFACT</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Paired immunoglobulin-like type 2 receptor beta</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UKX5 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UKX5">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ITGA11</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Integrin alpha-11</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UMR7 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UMR7">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CLEC4A</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin DDB27</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin superfamily member 6</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dendritic cell immunoreceptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lectin-like immunoreceptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">C-type lectin domain family 4 member A</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UN19 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UN19">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DAPP1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B lymphocyte adapter protein Bam32</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">B-cell adapter molecule of 32 kDa</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Dual adapter for phosphotyrosine and 3-phosphotyrosine and 3-phosphoinositide</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UNE0 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UNE0">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EDAR</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anhidrotic ectodysplasin receptor 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Downless homolog</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EDA-A1 receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ectodermal dysplasia receptor</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Ectodysplasin-A receptor</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Tumor necrosis factor receptor superfamily member EDAR</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UQQ2 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UQQ2">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH2B3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte adapter protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lymphocyte-specific adapter protein Lnk</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Signal transduction protein Lnk</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SH2B adapter protein 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9UQV4 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9UQV4">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">LAMP3</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">DC-lysosome-associated membrane glycoprotein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein TSC403</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lysosome-associated membrane glycoprotein 3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9Y286 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9Y286">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIGLEC7</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adhesion inhibitory receptor molecule 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CDw328</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">D-siglec</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">QA79 membrane protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">p75</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Sialic acid-binding Ig-like lectin 7</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9Y2J8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9Y2J8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PADI2</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">PAD-H19</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Peptidylarginine deiminase II</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein-arginine deiminase type II</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein-arginine deiminase type-2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9Y3P8 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9Y3P8">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SIT1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">SHP2-interacting transmembrane adapter protein</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Suppression-inducing transmembrane adapter 1</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gp30/40</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Signaling threshold-regulating transmembrane adapter 1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9Y5K6 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9Y5K6">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD2AP</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adapter protein CMS</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Cas ligand with multiple SH3 domains</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CD2-associated protein</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://www.uniprot.org/uniprot/Q9Y653 -->
+
+    <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q9Y653">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ADGRG1</cmi-pb:shortLabel>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">G-protein coupled receptor 56</obo:IAO_0000118>
+        <obo:IAO_0000118 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Protein TM7XN1</obo:IAO_0000118>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Adhesion G-protein coupled receptor G1</rdfs:label>
     </owl:Class>
     
 

--- a/src/build_proteins.py
+++ b/src/build_proteins.py
@@ -31,7 +31,8 @@ def main():
                   JOIN statements s2 ON s1.object = s2.subject
                 WHERE s1.subject IN ({proteins_str})
                   AND s1.predicate = 'uniprot_core:recommendedName'
-                  AND s2.predicate = 'uniprot_core:fullName';""")
+                  AND s2.predicate = 'uniprot_core:fullName';"""
+        )
         for res in cur.fetchall():
             uniprot = res[0].split(":")[1]
             details[uniprot] = {"label": res[1]}
@@ -61,7 +62,8 @@ def main():
                   JOIN statements s2 ON s1.object = s2.subject
                 WHERE s1.subject IN ({proteins_str})
                   AND s1.predicate = 'uniprot_core:alternativeName'
-                  AND s2.predicate = 'uniprot_core:fullName';""")
+                  AND s2.predicate = 'uniprot_core:fullName';"""
+        )
         for res in cur.fetchall():
             uniprot = res[0].split(":")[1]
             if uniprot not in synonyms:
@@ -83,13 +85,26 @@ def main():
 
     # Build the ROBOT template
     with open(args.output, "w") as f:
-        writer = csv.DictWriter(f, fieldnames=["uniprot_id", "parent", "label", "short_label", "synonyms"], delimiter="\t", lineterminator="\n")
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["uniprot_id", "parent", "label", "short_label", "synonyms"],
+            delimiter="\t",
+            lineterminator="\n",
+        )
         writer.writeheader()
         # Write ROBOT template strings
-        writer.writerow({"uniprot_id": "ID", "parent": "SC %", "label": "LABEL", "short_label": "A CMI_PB:shortLabel", "synonyms": "A IAO:0000118 SPLIT=|"})
+        writer.writerow(
+            {
+                "uniprot_id": "ID",
+                "parent": "SC %",
+                "label": "LABEL",
+                "short_label": "A CMI_PB:shortLabel",
+                "synonyms": "A IAO:0000118 SPLIT=|",
+            }
+        )
         # Write all rows
         writer.writerows(rows)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/build_proteins.py
+++ b/src/build_proteins.py
@@ -1,0 +1,95 @@
+import csv
+import sqlite3
+
+from argparse import ArgumentParser
+from collections import defaultdict
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("db")
+    parser.add_argument("proteins")
+    parser.add_argument("output")
+    args = parser.parse_args()
+
+    proteins = []
+    with open(args.proteins, "r") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            proteins.append(row["uniprot_id"])
+    proteins_str = ", ".join([f"'uniprot_protein:{x}'" for x in proteins])
+
+    details = defaultdict(dict)
+    with sqlite3.connect(args.db) as conn:
+        cur = conn.cursor()
+
+        # First get the labels, i.e. the recommended names
+        print("Getting recommended names...")
+        cur.execute(
+            f"""SELECT DISTINCT s1.subject, s2.value
+                FROM statements s1
+                  JOIN statements s2 ON s1.object = s2.subject
+                WHERE s1.subject IN ({proteins_str})
+                  AND s1.predicate = 'uniprot_core:recommendedName'
+                  AND s2.predicate = 'uniprot_core:fullName';""")
+        for res in cur.fetchall():
+            uniprot = res[0].split(":")[1]
+            details[uniprot] = {"label": res[1]}
+
+        # Then get the short labels, i.e. the gene names
+        print("Getting genes...")
+        cur.execute(
+            f"""SELECT DISTINCT s1.subject, s2.value
+                FROM statements s1
+                  JOIN statements s2 ON s1.object = s2.subject
+                WHERE s1.subject IN ({proteins_str})
+                  AND s1.predicate = 'uniprot_core:encodedBy'
+                  AND s2.predicate = 'skos:prefLabel'"""
+        )
+        for res in cur.fetchall():
+            uniprot = res[0].split(":")[1]
+            if uniprot not in details:
+                details[uniprot] = {}
+            details[uniprot]["short_label"] = res[1]
+
+        # Finally get the synonyms - there may be zero or more
+        synonyms = defaultdict(list)
+        print("Getting alternative names...")
+        cur.execute(
+            f"""SELECT DISTINCT s1.subject, s2.value
+                FROM statements s1
+                  JOIN statements s2 ON s1.object = s2.subject
+                WHERE s1.subject IN ({proteins_str})
+                  AND s1.predicate = 'uniprot_core:alternativeName'
+                  AND s2.predicate = 'uniprot_core:fullName';""")
+        for res in cur.fetchall():
+            uniprot = res[0].split(":")[1]
+            if uniprot not in synonyms:
+                synonyms[uniprot] = list()
+            synonyms[uniprot].append(res[1])
+
+        for uniprot, syns in synonyms.items():
+            details[uniprot]["synonyms"] = "|".join(syns)
+
+    missing = list(set(proteins) - set(details.keys()))
+    if missing:
+        print(f"WARNING: Missing {len(missing)} protein(s): " + ", ".join(missing))
+
+    rows = []
+    for uniprot, det in details.items():
+        det["uniprot_id"] = "uniprot:" + uniprot
+        det["parent"] = "PR:000000001"
+        rows.append(det)
+
+    # Build the ROBOT template
+    with open(args.output, "w") as f:
+        writer = csv.DictWriter(f, fieldnames=["uniprot_id", "parent", "label", "short_label", "synonyms"], delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        # Write ROBOT template strings
+        writer.writerow({"uniprot_id": "ID", "parent": "SC %", "label": "LABEL", "short_label": "A CMI_PB:shortLabel", "synonyms": "A IAO:0000118 SPLIT=|"})
+        # Write all rows
+        writer.writerows(rows)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/build_proteins.py
+++ b/src/build_proteins.py
@@ -98,7 +98,7 @@ def main():
                 "uniprot_id": "ID",
                 "parent": "SC %",
                 "label": "LABEL",
-                "short_label": "A CMI_PB:shortLabel",
+                "short_label": "A CMI-PB:shortLabel",
                 "synonyms": "A IAO:0000118 SPLIT=|",
             }
         )

--- a/src/ontology/prefixes.tsv
+++ b/src/ontology/prefixes.tsv
@@ -1,9 +1,9 @@
 prefix	base
+CMI_PB	https://cmi-pb.org/terminology/cmi-pb#
 rdf	http://www.w3.org/1999/02/22-rdf-syntax-ns#
 rdfs	http://www.w3.org/2000/01/rdf-schema#
 xsd	http://www.w3.org/2001/XMLSchema#
 owl	http://www.w3.org/2002/07/owl#
-uniprot	https://www.uniprot.org/uniprot/
 dc	http://purl.org/dc/terms/
 BFO	http://purl.obolibrary.org/obo/BFO_
 COB	http://purl.obolibrary.org/obo/COB_
@@ -19,3 +19,9 @@ PR	http://purl.obolibrary.org/obo/PR_
 UO	http://purl.obolibrary.org/obo/UO_
 VO	http://purl.obolibrary.org/obo/VO_
 ONTIE	https://ontology.iedb.org/ontology/ONTIE_
+faldo	http://biohackathon.org/resource/faldo#
+uniprot	https://www.uniprot.org/uniprot/
+uniprot_annotation	http://purl.uniprot.org/annotation/
+uniprot_core	http://purl.uniprot.org/core/
+uniprot_protein	http://purl.uniprot.org/uniprot/
+skos	http://www.w3.org/2004/02/skos/core#

--- a/src/ontology/prefixes.tsv
+++ b/src/ontology/prefixes.tsv
@@ -1,5 +1,4 @@
 prefix	base
-CMI_PB	https://cmi-pb.org/terminology/cmi-pb#
 rdf	http://www.w3.org/1999/02/22-rdf-syntax-ns#
 rdfs	http://www.w3.org/2000/01/rdf-schema#
 xsd	http://www.w3.org/2001/XMLSchema#

--- a/src/ontology/upper.tsv
+++ b/src/ontology/upper.tsv
@@ -19,5 +19,6 @@ IAO:0000118	alternative term	owl:AnnotationProperty
 IAO:0000115	definition	owl:AnnotationProperty
 IAO:0000119	definition source	owl:AnnotationProperty
 IAO:0000112	example of usage	owl:AnnotationProperty
+CMI_PB:shortLabel	short label	owl:AnnotationProperty		
 rdf:type	type	rdf:Property
 rdfs:subClassOf	subclass of	rdf:Property

--- a/src/ontology/upper.tsv
+++ b/src/ontology/upper.tsv
@@ -19,6 +19,6 @@ IAO:0000118	alternative term	owl:AnnotationProperty
 IAO:0000115	definition	owl:AnnotationProperty
 IAO:0000119	definition source	owl:AnnotationProperty
 IAO:0000112	example of usage	owl:AnnotationProperty
-CMI_PB:shortLabel	short label	owl:AnnotationProperty		
+CMI-PB:shortLabel	short label	owl:AnnotationProperty		
 rdf:type	type	rdf:Property
 rdfs:subClassOf	subclass of	rdf:Property

--- a/terminology/terminology.py
+++ b/terminology/terminology.py
@@ -7,6 +7,7 @@ CMI_PB_DB = "build/cmi-pb.db"
 
 PREDICATE_IDS = [
     "rdfs:label",
+    "CMI-PB:shortLabel",
     "IAO:0000118",
     "IAO:0000115",
     "IAO:0000119",


### PR DESCRIPTION
Resolves #7 

I also added a `CMI-PB:shortLabel` property that we can change to whatever we want. This is just for the gene names.

~When I did try to update `cmi-pb.owl` just by running `make cmi-pb.owl`, I got a very strange diff (the file looked OK in protege, though). I'm not sure if it's something going on with my system or something is actually broken? Here's just part of the diff, for example:~

~The definitions also disappeared from some IAO terms, but maybe that just has to do with the version of the imports. I think this is unrelated to this PR, though, unless my changes to `src/ontology/prefix.tsv` broke something? @jamesaoverton I would appreciate if you could take a look. Thanks!~

Disregard that last part, it's an issue with the `zcat` on my system.