### PR TITLE
Add query to create protein search table

### DIFF
--- a/cmi-pb.owl
+++ b/cmi-pb.owl
@@ -957,6 +957,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/A0A171JW18">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fim3</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fimbrial protein Fim3</rdfs:label>
     </owl:Class>
     
@@ -1523,6 +1524,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P04977">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptxA</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 1</rdfs:label>
     </owl:Class>
     
@@ -1532,6 +1534,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P04978">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptxB</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 2</rdfs:label>
     </owl:Class>
     
@@ -1541,6 +1544,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P04979">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptxC</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 3</rdfs:label>
     </owl:Class>
     
@@ -1550,6 +1554,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P04981">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptxE</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 5</rdfs:label>
     </owl:Class>
     
@@ -1813,6 +1818,7 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/P0A3R5">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ptxD</cmi-pb:shortLabel>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Pertussis toxin subunit 4</rdfs:label>
     </owl:Class>
     
@@ -3509,7 +3515,8 @@ exudate and epithelial debris for microbiological or cellular examination.</obo:
 
     <owl:Class rdf:about="https://www.uniprot.org/uniprot/Q5I8X0">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PR_000000001"/>
-        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fimbrial protein </rdfs:label>
+        <cmi-pb:shortLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fim2</cmi-pb:shortLabel>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Fimbrial protein</rdfs:label>
     </owl:Class>
     
 

--- a/src/ontology/terminology.tsv
+++ b/src/ontology/terminology.tsv
@@ -14,19 +14,19 @@ ab_titer.isotype	IgG4	http://purl.obolibrary.org/obo/PR_000050256	IgG4 heavy cha
 ab_titer.antigen	PT	https://ontology.iedb.org/ontology/ONTIE_0003550	Pertussis toxin complex	protein complex	The 1% PFA is a technical aspect as the protein was fixed with paraformaldehide. I included the detalis only for the Pertussis Toxin.	This is a protein complex, but we don't know where it lives, so we'll put it into ONTIE.
 ab_titer.antigen	1% PFA PT	https://ontology.iedb.org/ontology/ONTIE_0003551	Pertussis toxin complex, inactivated by PFA	protein complex	Same as above in the 1% PFA PT --> All subunits included
 ab_titer.antigen	PTM	https://ontology.iedb.org/ontology/ONTIE_0003552	Pertussis toxin complex, inactivated mutant	protein complex	This is a Pertussis Toxin mutant from List Biologicals only some aa modifications added, not sure how this works with ontologies--> https://www.listlabs.com/products/buy-pertussis-toxin-mutant
-		https://www.uniprot.org/uniprot/P04977	Pertussis toxin subunit 1	protein	The pertussis Toxin is conformed of 5 subunits (S1, S2, S3, S4 and S5). Those are all contained in this term so it is a mixture of all 5 subunits (I added the Ontology ID for all of those)
-		https://www.uniprot.org/uniprot/P04978	Pertussis toxin subunit 2	protein	
-		https://www.uniprot.org/uniprot/P04979	Pertussis toxin subunit 3	protein	
-		https://www.uniprot.org/uniprot/P0A3R5	Pertussis toxin subunit 4	protein	
-		https://www.uniprot.org/uniprot/P04981	Pertussis toxin subunit 5	protein	
+	ptxA	https://www.uniprot.org/uniprot/P04977	Pertussis toxin subunit 1	protein	The pertussis Toxin is conformed of 5 subunits (S1, S2, S3, S4 and S5). Those are all contained in this term so it is a mixture of all 5 subunits (I added the Ontology ID for all of those)
+	ptxB	https://www.uniprot.org/uniprot/P04978	Pertussis toxin subunit 2	protein	
+	ptxC	https://www.uniprot.org/uniprot/P04979	Pertussis toxin subunit 3	protein	
+	ptxD	https://www.uniprot.org/uniprot/P0A3R5	Pertussis toxin subunit 4	protein	
+	ptxE	https://www.uniprot.org/uniprot/P04981	Pertussis toxin subunit 5	protein	
 ab_titer.antigen	ACT	https://www.uniprot.org/uniprot/C8C508	Adenylate cyclase toxin	protein
 ab_titer.antigen	BETV1	https://www.uniprot.org/uniprot/O23748	Pollen allergen, Betv1	protein
 ab_titer.antigen	DT	https://www.uniprot.org/uniprot/Q5PY51	Diphtheria toxin	protein	In this case is the toxoid --> 1% PFA inactivated
 ab_titer.antigen	FELD1	https://www.uniprot.org/uniprot/P30438	Major allergen I polypeptide chain 1	protein	Cat allergen
 ab_titer.antigen	FHA	https://www.uniprot.org/uniprot/P12255	Filamentous hemagglutinin	protein	
 ab_titer.antigen	FIM2/3	https://ontology.iedb.org/ontology/ONTIE_0003553	Mixture of Fim2 and Fim3	mixture	Contains 2 fimbriae proteins FIM2 and FIM3.
-		https://www.uniprot.org/uniprot/Q5I8X0	Fimbrial protein 	protein	Fim2
-		https://www.uniprot.org/uniprot/A0A171JW18	Fimbrial protein Fim3	protein	Fim3
+	fim2	https://www.uniprot.org/uniprot/Q5I8X0	Fimbrial protein 	protein	Fim2
+	fim3	https://www.uniprot.org/uniprot/A0A171JW18	Fimbrial protein Fim3	protein	Fim3
 ab_titer.antigen	LOLP1	https://www.uniprot.org/uniprot/P14946	Pollen allergen Lol p 1	protein	Pollen allergen
 ab_titer.antigen	LOS	http://purl.obolibrary.org/obo/CHEBI_35371	lipooligosaccharide	molecular entity	Bordetella pertussis has a distinctive cell wall lipooligosaccharide (LOS)
 ab_titer.antigen	Measles	http://purl.obolibrary.org/obo/VO_0010784	Measles virus protein	vaccine	Thie refers to the viral proteins

--- a/src/protein_search.sql
+++ b/src/protein_search.sql
@@ -1,0 +1,33 @@
+DROP TABLE IF EXISTS protein_search;
+
+CREATE TABLE protein_search (
+  id TEXT NOT NULL,
+  short_label TEXT,
+  label TEXT NOT NULL,
+  synonym TEXT
+);
+
+-- Insert ALL proteins with empty synonym value
+INSERT INTO protein_search (id, short_label, label)
+  SELECT s1.stanza AS id,
+    s2.value AS short_label,
+    s1.value AS label
+  FROM statements s1
+  JOIN statements s2 ON s1.stanza = s2.stanza
+  WHERE s1.stanza LIKE 'uniprot:%'
+    AND s1.predicate = 'rdfs:label'
+    AND s2.predicate = 'CMI-PB:shortLabel';
+
+-- Then add the rows with synonyms
+INSERT INTO protein_search (id, short_label, label, synonym)
+  SELECT s1.stanza AS id,
+    s2.value AS short_label,
+    s1.value AS label,
+    s3.value AS synonym
+  FROM statements s1
+  JOIN statements s2 ON s1.stanza = s2.stanza
+  JOIN statements s3 ON s1.stanza = s3.stanza
+  WHERE s1.stanza LIKE 'uniprot:%'
+    AND s1.predicate = 'rdfs:label'
+    AND s2.predicate = 'CMI-PB:shortLabel'
+    AND s3.predicate = 'IAO:0000118';

--- a/src/protein_search.sql
+++ b/src/protein_search.sql
@@ -4,7 +4,8 @@ CREATE TABLE protein_search (
   id TEXT NOT NULL,
   short_label TEXT,
   label TEXT NOT NULL,
-  synonym TEXT
+  synonym TEXT,
+  synonym_property TEXT
 );
 
 -- Insert ALL proteins with empty synonym value
@@ -19,11 +20,12 @@ INSERT INTO protein_search (id, short_label, label)
     AND s2.predicate = 'CMI-PB:shortLabel';
 
 -- Then add the rows with synonyms
-INSERT INTO protein_search (id, short_label, label, synonym)
+INSERT INTO protein_search
   SELECT s1.stanza AS id,
     s2.value AS short_label,
     s1.value AS label,
-    s3.value AS synonym
+    s3.value AS synonym,
+    'IAO:0000118' AS synonym_property
   FROM statements s1
   JOIN statements s2 ON s1.stanza = s2.stanza
   JOIN statements s3 ON s1.stanza = s3.stanza


### PR DESCRIPTION
Resolves #8 - for each item, there is also a row with no synonym (for cases where the synonym does not match the search). I ended up adding in the `synonym_property` column; we may end up with different synonym properties due to the OIO synonyms for other searches. This query should work for both SQLite and Postgres.

I also updated the terminology Google sheet to add the gene names where missing to the Uniprot proteins (hence the changes to `cmi-pb.owl`). I wanted to make sure that all Uniprot entries had a short label, and I confirmed that they now do.

@jamesaoverton do we want this step somewhere in the `Makefile` or should we just leave the query alone for now? Also, do we want to maybe make a `src/scripts/` directory to store various `.sql` & `.py` files?