### PR TITLE
Check for foreign keys also in conflict tables

### DIFF
--- a/test/expected/messages_a1.tsv
+++ b/test/expected/messages_a1.tsv
@@ -30,4 +30,4 @@ foobar	C4	error	under:not-under	Value 'g' of column xyzzy is not under 'd'	g
 foobar	D4	error	rule:foo-4	bar must be 'y' or 'z' if foo is 'x'	x
 foobar	C5	error	under:not-under	Value 'h' of column xyzzy is not under 'd'	h
 foobar	C7	error	under:not-in-tree	Value z of column xyzzy is not in foobar.child	z
-foobar	A9	error	key:foreign	Value i of column child is not in foreign_table.foreign_column	i
+foobar	A9	error	key:foreign	Value i of column child exists only in foreign_table_conflict.other_foreign_column	i

--- a/test/expected/messages_non_a1.tsv
+++ b/test/expected/messages_non_a1.tsv
@@ -30,4 +30,4 @@ foobar	4	xyzzy	error	under:not-under	Value 'g' of column xyzzy is not under 'd'	
 foobar	4	foo	error	rule:foo-4	bar must be 'y' or 'z' if foo is 'x'	x
 foobar	5	xyzzy	error	under:not-under	Value 'h' of column xyzzy is not under 'd'	h
 foobar	7	xyzzy	error	under:not-in-tree	Value z of column xyzzy is not in foobar.child	z
-foobar	9	child	error	key:foreign	Value i of column child is not in foreign_table.foreign_column	i
+foobar	9	child	error	key:foreign	Value i of column child exists only in foreign_table_conflict.other_foreign_column	i

--- a/test/src/column.tsv
+++ b/test/src/column.tsv
@@ -28,9 +28,10 @@ import	id		CURIE	unique
 import	label		label	primary	
 import	parent	empty	label	tree(label)	
 import	related	empty	trimmed_line		
-foobar	child		trimmed_line	from(foreign_table.foreign_column)	
+foobar	child		trimmed_line	from(foreign_table.other_foreign_column)	
 foobar	parent	empty	trimmed_line	tree(child)	
 foobar	xyzzy	empty	trimmed_line	under(foobar.child, d)	
 foobar	foo	empty	text		
 foobar	bar	empty	text		
 foreign_table	foreign_column		text	primary	
+foreign_table	other_foreign_column		text	unique	

--- a/test/src/ontology/foreign_table.tsv
+++ b/test/src/ontology/foreign_table.tsv
@@ -1,9 +1,10 @@
-foreign_column
-a
-b
-c
-d
-e
-f
-g
-h
+foreign_column	other_foreign_column
+a	a
+b	b
+c	c
+d	d
+e	e
+f	f
+g	g
+h	h
+a	i


### PR DESCRIPTION
When a foreign key value does not exist in the 'normal' version of a table, check if it is in the conflict table, and if so, indicate this in the error message.

Closes #60 